### PR TITLE
[update] テストでモックをClearではなくResetのほうが良かったので変更

### DIFF
--- a/__tests__/components/forms/SignUpForm.test.tsx
+++ b/__tests__/components/forms/SignUpForm.test.tsx
@@ -14,7 +14,7 @@ jest.mock("firebase/auth", () => ({
 
 describe("SignUpForm", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     (signUpWithEmail as jest.Mock).mockResolvedValue({
       user: {},
     });

--- a/__tests__/hooks/auth/useLogInEmailUser.test.ts
+++ b/__tests__/hooks/auth/useLogInEmailUser.test.ts
@@ -11,7 +11,7 @@ jest.mock("@/lib/authentication", () => ({
 
 describe("useLogInEmailUser", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   test("should have init value", () => {

--- a/__tests__/hooks/auth/useRegisterEmailUser.test.ts
+++ b/__tests__/hooks/auth/useRegisterEmailUser.test.ts
@@ -18,7 +18,7 @@ describe("useRegisterEmailUser", () => {
   const mockPassword = "Password123";
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   test("should have init values", async () => {

--- a/__tests__/lib/authentication.test.ts
+++ b/__tests__/lib/authentication.test.ts
@@ -29,7 +29,7 @@ const mockEmail = "test@example.com";
 const mockPassword = "password123";
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  jest.resetAllMocks();
 });
 
 describe("signUpWithEmail", () => {


### PR DESCRIPTION
mockを外で設定しているもの以外はresetで値も一緒にきれいにしておくほうが良さそうだったので、変更

- https://dev.classmethod.jp/articles/jest-the-difference-between-clearallmocks-and-resetallmocks/
- https://jestjs.io/docs/jest-object#jestclearallmocks
- https://jestjs.io/docs/jest-object#jestresetallmocks