### PR TITLE
[update] ESLintで明示的に_始まりの引数名は未使用でも見逃すように設定変更

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,7 +54,7 @@ const eslintConfig = [
         },
       ],
       "no-useless-assignment": "error",
-      "no-unused-vars": "error",
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
       eqeqeq: "error",
       "no-useless-return": "error",
       "prefer-const": "error",


### PR DESCRIPTION
クラスを作ろうとした時にコールバック定義で引っかかったので、追加。

クラス追加自体はなくなったが、設定として入れておいてもよさそうなので追加