### PR TITLE
[update] 時間記録の保存ボタンを押した時に、まずは時間を止めるように変更

### DIFF
--- a/src/modules/timer/StopwatchComponent.tsx
+++ b/src/modules/timer/StopwatchComponent.tsx
@@ -16,6 +16,8 @@ const StopwatchComponent = () => {
       return;
     }
 
+    stop();
+
     // TODO: 動作確認用に一旦おいておく
     const recordTime = formatTime(elapsedTime);
     const startedTime = new Date(startTime).toLocaleString("ja-JP");


### PR DESCRIPTION
保存してから時間をResetしていたので、たまにボタンを押してもしばらく動いてたので、動かないように変更