### PR TITLE
[update] Firestoreに保存されていない日のデータは0でChartには表示するように変更

### DIFF
--- a/__tests__/lib/getTimeRecords.test.ts
+++ b/__tests__/lib/getTimeRecords.test.ts
@@ -15,8 +15,10 @@ jest.mock("@/types/TimeRecordSummary", () => ({
 describe("getTimeRecords", () => {
   describe("getMonthlyDailySummary", () => {
     const userId = "testUser";
-    const year = "2023";
-    const month = "01";
+    const year = 2023;
+    const month = 1;
+    const monthDaysLength = new Date(year, month + 1, 0).getDate();
+    const formatMonth = (month + 1).toString().padStart(2, "0");
     const mockDocs = [
       { id: "01", data: () => ({ totalTime: 120 }) },
       { id: "02", data: () => ({ totalTime: 150 }) },
@@ -32,23 +34,20 @@ describe("getTimeRecords", () => {
       await getMonthlyDailySummary(userId, year, month);
       expect(collection).toHaveBeenCalledWith(
         db,
-        `users/${userId}/summaries/${year}/monthly/${month}/daily`,
+        `users/${userId}/summaries/${year}/monthly/${formatMonth}/daily`,
       );
     });
 
-    test("should return the correct daily summaries", async () => {
+    test("should return summary length is equal days length if some docs", async () => {
       (isTimeRecordSummary as unknown as jest.Mock).mockReturnValue(true);
       const result = await getMonthlyDailySummary(userId, year, month);
-      expect(result).toEqual([
-        { day: "01", totalTime: 120 },
-        { day: "02", totalTime: 150 },
-      ]);
+      expect(result.length).toBe(monthDaysLength);
     });
 
-    test("should handle empty collections", async () => {
+    test("should return summary length is equal days length if no doc", async () => {
       (getDocs as jest.Mock).mockResolvedValue({ docs: [] });
       const result = await getMonthlyDailySummary(userId, year, month);
-      expect(result).toEqual([]);
+      expect(result.length).toBe(monthDaysLength);
     });
   });
 });

--- a/src/app/records/page.tsx
+++ b/src/app/records/page.tsx
@@ -3,6 +3,7 @@
 import { DailyChart } from "@/components/charts/DailyChart";
 import { useLoggedInUser } from "@/hooks/auth/useLoggedInUser";
 import { getMonthlyDailySummary } from "@/lib/getTimeRecords";
+import { TimeRecordPoint } from "@/types/TimeRecordChartPoint";
 import Link from "next/link";
 import { useState } from "react";
 /**
@@ -11,14 +12,12 @@ import { useState } from "react";
  */
 export default function Records() {
   const { loginUser } = useLoggedInUser();
-  const [data, setData] = useState<
-    { day: string; totalTime: number }[] | null
-  >();
+  const [data, setData] = useState<TimeRecordPoint[] | null>();
 
   // TODO: カスタムフックにまとめたり、ContainerでWrapしたりしてChart関係を分離する
   const now = new Date(Date.now());
-  const year = now.getFullYear().toString();
-  const month = (now.getMonth() + 1).toString().padStart(2, "0");
+  const year = now.getFullYear();
+  const month = now.getMonth();
   if (loginUser && !data) {
     getMonthlyDailySummary(loginUser.uid, year, month).then((response) => {
       // TODO: 記録が存在しない日は0でChartに表示できるようにデータを追加する
@@ -35,7 +34,7 @@ export default function Records() {
       <button>
         <Link href="/timer">時間計測ページへ</Link>
       </button>
-      {data && <h2>{`${year} ${month}`}月</h2>}
+      {data && <h2>{`${year} ${month + 1}`}月</h2>}
       {data && <DailyChart data={data} />}
     </div>
   );

--- a/src/lib/getTimeRecords.ts
+++ b/src/lib/getTimeRecords.ts
@@ -1,4 +1,5 @@
 import { db } from "@/configs/firebaseConfig";
+import { TimeRecordPoint } from "@/types/TimeRecordChartPoint";
 import {
   isTimeRecordSummary,
   TimeRecordSummary,
@@ -7,25 +8,41 @@ import { collection, getDocs } from "firebase/firestore";
 
 export const getMonthlyDailySummary = async (
   userId: string,
-  year: string,
-  month: string,
+  year: number,
+  month: number,
 ) => {
+  // DD
   const dailyCollectionRef = collection(
     db,
-    `users/${userId}/summaries/${year}/monthly/${month}/daily`,
+    `users/${userId}/summaries/${year.toString()}/monthly/${formatMonthText(month)}/daily`,
   );
-  const querySnapshot = await getDocs(dailyCollectionRef);
-  return querySnapshot.docs.map((doc) => {
-    const record: TimeRecordSummary = isTimeRecordSummary(doc.data())
-      ? (doc.data() as TimeRecordSummary)
-      : {
-          totalTime: 0,
-          recordCount: 0,
-        };
 
-    return {
-      day: doc.id,
-      totalTime: record.totalTime,
+  const querySnapshot = await getDocs(dailyCollectionRef);
+  const saveDataMap = new Map(
+    querySnapshot.docs.map((doc) => {
+      const record: TimeRecordSummary = isTimeRecordSummary(doc.data())
+        ? (doc.data() as TimeRecordSummary)
+        : {
+            totalTime: 0,
+            recordCount: 0,
+          };
+
+      return [doc.id, record.totalTime];
+    }),
+  );
+
+  // month 月の最終日 → month 月の日付の数
+  const monthDaysLength = new Date(year, month + 1, 0).getDate();
+  return Array.from({ length: monthDaysLength }, (_, i) => {
+    const day = formatMonthText(i);
+    const data: TimeRecordPoint = {
+      day: day,
+      totalTime: saveDataMap.get(day) ?? 0,
     };
+    return data;
   });
+};
+
+const formatMonthText = (month: number) => {
+  return (month + 1).toString().padStart(2, "0");
 };


### PR DESCRIPTION
Firestoreに保存されているデータだけを表示していましたが、保存されていない日のデータを0で追加するように変更し、  
Chartでは今月分すべてが表示されるChartになるように変更。