### PR TITLE
[update] SCSSでwarningが出ていたので対応

### DIFF
--- a/src/app/records/page.tsx
+++ b/src/app/records/page.tsx
@@ -21,7 +21,6 @@ export default function Records() {
   const month = now.getMonth();
   if (loginUser && !data) {
     getMonthlyDailySummary(loginUser.uid, year, month).then((response) => {
-      // TODO: 記録が存在しない日は0でChartに表示できるようにデータを追加する
       setData(response);
     });
   }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -2,6 +2,11 @@
   --color-text-white: #ededed;
   --color-text-black: #474747;
 
+  color: $color-text;
+  background: $color-background;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
   @include theme-color-variables(
     #fcfaf6,
     var(--color-text-black),
@@ -19,11 +24,6 @@
       $dark-color-green
     );
   }
-
-  color: $color-text;
-  background: $color-background;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 
   html,
   body {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // ライト←→ダークによって変わる色のうち、計算が必要なもの
 $light-color-green: #0a9691;
 $dark-color-green: #04d4cb;
@@ -7,9 +9,9 @@ $dark-color-green: #04d4cb;
   --color-base: #{$base};
   --color-text: #{$text};
   --color-green: #{$color};
-  --color-green-hover: #{darken($color, 10%)};
+  --color-green-hover: #{color.adjust($color, $lightness: -10%, $space: hsl)};
   --color-green-hover-bg: #{rgba($color, 0.1)};
-  --color-green-disabled: #{grayscale($color)};
+  --color-green-disabled: #{color.grayscale($color)};
 }
 
 $color-base: var(--color-base);


### PR DESCRIPTION
SCSSのwarning対応。  
ついでにTODOコメントが不要になっていたので削除

▼ `npx sass-migrator color .\src\styles\variables.scss`で解決  
（`@use "sass:color";`と`#{color.adjust($color, $lightness: -10%, $space: hsl)}`）

```txt
⚠ ./src/styles/globals.scss
Issue while running loader
SassWarning: Deprecation Warning on line 9, column 25 of file:///D:/mi/Edit/project/ticktack-diary/src/styles/variables.scss:9:25:
darken() is deprecated. Suggestions:

color.scale($color, $lightness: -23.6111111111%)
color.adjust($color, $lightness: -10%)

More info: https://sass-lang.com/d/color-functions

9 |   --color-green-hover: #{darken($color, 10%)};


src\styles\variables.scss 10:26  theme-color-variables()
src\styles\globals.scss 17:5     root stylesheet
```

▼ 今回は指定位置を上に移動してよかったので移動（4つ移動）

```txt
⚠ ./src/styles/globals.scss
Issue while running loader
SassWarning: Deprecation Warning on line 25, column 2 of file:///D:/mi/Edit/project/ticktack-diary/src/styles/globals.scss:25:2:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

25 |   -webkit-font-smoothing: antialiased;


src\styles\globals.scss 26:3  root stylesheet
```

▼ `color.grayscale`に置き換え

```txt
 ⚠ ./src/styles/globals.scss
Issue while running loader
SassWarning: Deprecation Warning on line 13, column 28 of file:///D:/mi/Edit/project/ticktack-diary/src/styles/variables.scss:13:28:
Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.grayscale instead.

More info and automated migrator: https://sass-lang.com/d/import

13 |   --color-green-disabled: #{grayscale($color)};


src\styles\variables.scss 14:29  theme-color-variables()
src\styles\globals.scss 11:3     root stylesheet
```