### PR TITLE
[update] Vercel CLIのauditがきれいにできそうになるまではnpxで使うので、インストールもコマンドではyに。

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "go-test": "go test -v -cover ./api/...",
-    "env-pull": "npx vercel env pull"
+    "env-pull": "npx vercel env pull -y"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
以下が毎回出るので yを先に指定しておく

```txt
vercel@41.2.1
Ok to proceed? (y)
```