### PR TITLE
[update] VercelFunctionsのためにvercel devしてもローカルの.envファイルの環境変数でDB接続できるように環境変数の調整

### DIFF
--- a/api/_util/auth/auth.go
+++ b/api/_util/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
@@ -15,7 +16,13 @@ var authClient *auth.Client
 var VerifyToken = VerifyTokenImplementation
 
 func init() {
-	opt := option.WithCredentialsJSON([]byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")))
+	decode, decodeErr := base64.StdEncoding.DecodeString(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+	if decodeErr != nil {
+		fmt.Printf("環境変数のデコードエラー: %v\n", decodeErr)
+		return
+	}
+
+	opt := option.WithCredentialsJSON([]byte(decode))
 	app, err := firebase.NewApp(context.Background(), nil, opt)
 	if err != nil {
 		fmt.Printf("Firebase 初期化エラー: %v\n", err)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "vercel-dev": "npx vercel dev",
+    "vercel-dev": "npx vercel dev -y",
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
ローカルではlocalhostでPostgreSQLのDBを作って試せるようにしたかったので、それを実現するために環境変数の調整が必要だったので調整しました。

1. ローカルのDBにローカルでは接続したい
2. ローカルでは環境変数`DATABASE_URL`を変更すればいい！
3. .env.localではvercel devでメモリに読み込まれる変数が優先されてしまいVercelで設定している環境変数の値が入ってしまう
4. vercel dev しないとVercelFunctions（REST API）が404になってしまうので、vercel devする必要がある
5. `.env`ならvercelで設定している環境変数に勝てる
6. おそらく上書きではなく環境変数ファイルの存在そのものが置き換わる？
7. `DATABASE_URL`以外の環境変数も.envで指定しておく必要がある
8. `GOOGLE_APPLICATION_CREDENTIALS`は中身JSONなので.envではうまく指定できない
9. 仕方ないのでbase64に変換したものをVercelと.envとで使うように変更

という流れで今回の内容を行いました。

また、ついでにpackageのscriptのオプションで「installしていいですか？」って聞かれるやつはyでいいので指定しておくように変更